### PR TITLE
Corrigir estilo pep8 no models.py & forms.py

### DIFF
--- a/app/petition/forms.py
+++ b/app/petition/forms.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from flask_wtf import Form, RecaptchaField
-from wtforms import TextField, PasswordField, ValidationError
+from flask_wtf import Form
+from wtforms import TextField, ValidationError
 from wtforms.validators import Required, Email
 from pycpfcnpj import cpfcnpj
-from app import db
 from models import Signature
 from utils.unique import Unique
+
 
 def validate_registration(form, field):
     # TODO: Improve string sanatization
@@ -24,9 +24,12 @@ class SignatureForm(Form):
     )
     email = TextField(
         'Endereço de email',
-        [Email(), Required(message=u'Preencha com seu endereço de email'), Unique(Signature, Signature.email)]
+        [Email(), Required(
+            message=u'Preencha com seu endereço de email'),
+            Unique(Signature, Signature.email)]
     )
     registration = TextField(
         'CPF',
-        [Required(message='Preencha com seu CPF'), validate_registration, Unique(Signature, Signature.registration)]
+        [Required(message='Preencha com seu CPF'), validate_registration,
+         Unique(Signature, Signature.registration)]
     )

--- a/app/petition/models.py
+++ b/app/petition/models.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from app import db
 
+
 class Base(db.Model):
 
     __abstract__ = True


### PR DESCRIPTION
Organizar estilo pep8 em models.py

`from app import db`
`+`
`+`
`class Base(db.Model):`

segundo a padrão de estilo `PEP8` os `imports` listadas abaixo deveram ser retiradas 
pois os mesmos não estão sendo utilizados .

```
RecaptchaField
PasswordField
from app import db 
```
